### PR TITLE
DHP-85

### DIFF
--- a/Arc/Components/Survey/Models/QuestionType.swift
+++ b/Arc/Components/Survey/Models/QuestionType.swift
@@ -122,6 +122,7 @@ public enum QuestionType : String, Codable {
 			inputView.maxCharacters = 2
 			inputView.minCharacters = 1
 			inputView.keyboardType = .numberPad
+            inputView.textView.reloadInputViews()
 		
 		case .image:
 			let inputView:SignatureView =  .get()


### PR DESCRIPTION
Alpha numeric keyboard was showing, because the code wasn't reloading the input view after switching to numberPad keyboard.  

Not sure with github's diff is showing the tab mis-alignment, it is fine in Xcode.