### PR TITLE
DIAN-612

### DIFF
--- a/Arc/App/Utilities/Model/TestSession.swift
+++ b/Arc/App/Utilities/Model/TestSession.swift
@@ -166,9 +166,13 @@ public struct FullTestSession : Codable {
 			cognitive.symbol_test = survey
 
 		}
-		if cognitive.context_survey != nil {
+		if cognitive.context_survey != nil ||
+            cognitive.wake_survey != nil ||
+            cognitive.chronotype_survey != nil ||
+            cognitive.price_test != nil ||
+            cognitive.grid_test != nil ||
+            cognitive.symbol_test != nil {
 			tests.append(AnyTest(cognitive))
-
 		}
 		
 		

--- a/Arc/Components/TestManager/ViewControllers/Prices Test/PricesTestViewController.swift
+++ b/Arc/Components/TestManager/ViewControllers/Prices Test/PricesTestViewController.swift
@@ -80,7 +80,8 @@ public class PricesTestViewController: ArcViewController {
 		}
 
 		if autoStart {
-            test = controller.loadTest(index: 0, file: PricesTestViewController.testVersion )
+            let sessionId = Int(Arc.shared.appController.currentSessionID)
+            test = controller.loadTest(index: sessionId, file: PricesTestViewController.testVersion )
             self.isTutorial = false
             responseID = controller.createResponse(withTest: test!)
 			


### PR DESCRIPTION
@nategbrown9 see https://sagebionetworks.jira.com/browse/DIAN-612

The price tests have a large set of potential prices to show users.  On Android, the index of the current session (session ID) is the index of the price sets it uses when choosing prices to show the user.

However, on iOS there was a bug, where it was always showing index 0, the first price set.  This code fixes that by setting the index equal to the current session ID.

This PR also includes a future-proof fix where test results are always included, even if the user did not take a context survey, which is how MTB will be.