### PR TITLE
Public visibility for fields

### DIFF
--- a/Arc/App/Utilities/Model/TestSession.swift
+++ b/Arc/App/Utilities/Model/TestSession.swift
@@ -54,13 +54,13 @@ public struct CognitiveTest : ArcCodable {
 	
 	public var id:String?
 	public var type:SurveyType? = .cognitive
-	var context_survey:SurveyResponse?
-	var wake_survey:SurveyResponse?
-	var chronotype_survey:SurveyResponse?
-	var grid_test:GridTestResponse?
-	var price_test:PriceTestResponse?
-	var symbol_test:SymbolsTestResponse?
-	init() {
+	public var context_survey:SurveyResponse?
+	public var wake_survey:SurveyResponse?
+	public var chronotype_survey:SurveyResponse?
+	public var grid_test:GridTestResponse?
+	public var price_test:PriceTestResponse?
+	public var symbol_test:SymbolsTestResponse?
+	public init() {
 		
 	}
 }

--- a/Arc/Arc.swift
+++ b/Arc/Arc.swift
@@ -43,6 +43,10 @@ public enum ArcBundle {
 public struct ArcAssessmentResult {
     public var signatures: [ArcAssessmentSignature]? = nil
     public var fullTestSession: FullTestSession? = nil
+    public init(signatures: [ArcAssessmentSignature]?, fullTestSession: FullTestSession?) {
+        self.signatures = signatures
+        self.fullTestSession = fullTestSession
+    }
 }
 
 public protocol ArcAssessmentDelegate: AnyObject {


### PR DESCRIPTION
Expose fields publicly.  Used when re-driving uploads.

@nategbrown9 review, merging for testing in main app.