### PR TITLE
Replace transitioning modals with a page view controller

### DIFF
--- a/Arc/Components/CognitiveImpl/ARCCognitiveState.swift
+++ b/Arc/Components/CognitiveImpl/ARCCognitiveState.swift
@@ -32,27 +32,17 @@ import UIKit
 
 public enum ARCCognitiveState : String, State, CaseIterable {
     
-    case home, gridTest, priceTest, symbolsTest, testIntro, signatureStart, signatureEnd
+    case home, testIntro, gridTest, priceTest, symbolsTest
 
     public func viewForState() -> UIViewController {
         let testIdx = 1
         ACState.testTaken = testIdx
         let pauseModal = CancelButtonModal.createPauseButtonModal()
         switch self {
-            
-        case .signatureStart:
-            let vc:ACSignatureNavigationController = .get()
-            vc.tag = 0            
-            vc.loadSurvey(template: "signature")
-            return vc
-        case .signatureEnd:
-            let vc:ACSignatureNavigationController = .get()
-            vc.tag = 1
-            vc.loadSurvey(template: "signature")
-            return vc
-        case .testIntro:
+
+        case .testIntro, .home:
             ACState.testCount = 1
-            return ACState.testIntro.viewForState()
+            return ACState.testIntro.viewForState()  
         case .gridTest:
             let controller:InstructionNavigationController = .get()
             controller.cancelButtonModal = pauseModal
@@ -122,8 +112,6 @@ public enum ARCCognitiveState : String, State, CaseIterable {
             controller.load(instructions: "TestingIntro-Symbols")
             return controller
             
-        case .home:
-            return (Arc.shared.appNavigation as! ARCCognitiveNavigationController).vcDelegate!.homeViewController()
         }
     }
 

--- a/Arc/Components/CognitiveImpl/ARCCognitiveState.swift
+++ b/Arc/Components/CognitiveImpl/ARCCognitiveState.swift
@@ -42,7 +42,7 @@ public enum ARCCognitiveState : String, State, CaseIterable {
 
         case .testIntro, .home:
             ACState.testCount = 1
-            return ACState.testIntro.viewForState()  
+            return ACState.testIntro.viewForState()
         case .gridTest:
             let controller:InstructionNavigationController = .get()
             controller.cancelButtonModal = pauseModal


### PR DESCRIPTION
Turns out that DIAN ARC apps do not use this “NavigationController” singleton so it was fairly straight-forward to replace it with a page view controller.

Note: A page view controller is *very* old tech and animations aren't super smooth on older devices, but unlike using modals and windows, it is self-contained and doesn't make any assumptions about *what* is being used to present it.